### PR TITLE
Permitir configurar FOV en opciones

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,13 +142,17 @@
           <strong>Mouse</strong> mirar · <strong>Shift</strong> correr ·
           <strong>R</strong> reiniciar · <strong>Esc</strong> liberar puntero.
         </p>
+        <label>
+          FOV: <span id="fovValue">90</span>°
+          <input id="fovRange" type="range" min="60" max="120" value="90" />
+        </label>
         <button id="startBtn">Iniciar</button>
       </div>
     </div>
 
     <script>
       // ===== Config =====
-      const FOV = Math.PI / 2; // 90° campo de visión (Quake-like)
+      let FOV = Math.PI / 2; // 90° campo de visión (Quake-like)
       const MOVE_SPEED = 3.2;
       const RUN_MULT = 1.8;
       const ROT_SPEED_MOUSE = 0.0022; // yaw
@@ -239,12 +243,18 @@
       // Pointer lock para mirar con mouse
       const overlay = document.getElementById("overlay");
       const startBtn = document.getElementById("startBtn");
+      const fovRange = document.getElementById("fovRange");
+      const fovValue = document.getElementById("fovValue");
       startBtn.addEventListener("click", () => {
         canvas.requestPointerLock();
       });
       document.addEventListener("pointerlockchange", () => {
         const locked = document.pointerLockElement === canvas;
         overlay.classList.toggle("hidden", locked);
+      });
+      fovRange.addEventListener("input", () => {
+        FOV = (fovRange.value * Math.PI) / 180;
+        fovValue.textContent = fovRange.value;
       });
       window.addEventListener("mousemove", (e) => {
         if (document.pointerLockElement === canvas) {


### PR DESCRIPTION
## Summary
- Agrega control deslizante para configurar el campo de visión desde la pantalla de inicio
- Actualiza el valor de FOV en tiempo real al mover el control

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a5bd2a5fb8832c9cbd2225c0dc9822